### PR TITLE
debug: Heredoc parser problem

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/04 15:15:23 by zslowian          #+#    #+#             */
-/*   Updated: 2025/04/11 22:59:51 by zslowian         ###   ########.fr       */
+/*   Updated: 2025/04/13 19:07:05 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -104,11 +104,11 @@ enum	e_token_types
 	WORD,
 	VAR,
 	PIPE,
-	INPUT,
-	TRUNC,
-	HEREDOC,
-	APPEND,
-	END
+	INPUT, // 5
+	TRUNC, // 6
+	HEREDOC, // 7
+	APPEND, // 8
+	END // 9
 };
 
 enum	e_quotes_status

--- a/parser.c
+++ b/parser.c
@@ -94,11 +94,20 @@ static bool	forbidden_consecutives(t_token *token_node)
 	if (token_node->prev)
 	{
 		if (token_node->type == PIPE && token_node->prev->type == PIPE)
+		{
+			ft_printf("Two pipes\n");
 			return (true);
+		}
 		if (token_node->type > PIPE && token_node->prev->type > PIPE)
+		{
+			ft_printf("Two extras bigger than pipe, ie \"<<\"\n");
 			return (true);
+		}
 		if (token_node->type == END && token_node->prev->type >= PIPE)
+		{
+			ft_printf("Unended pipe\n");
 			return (true);
+		}
 	}
 	return (false);
 }
@@ -113,11 +122,11 @@ int	verify_double_separators(t_token **token_lst)
 		if (forbidden_consecutives(temp))
 		{
 			if (temp->type == END && temp->prev && temp->prev->type > PIPE)
-				write(2, "syntax error\n", 13);
+				write(2, "syntax error: Unended pipe again\n", 34);
 			else if (temp->type == END && temp->prev)
 				write(2, "syntax error\n", 13);
 			else
-				write(2, "syntax error\n", 13);
+				write(2, "syntax error fallback\n", 23);
 			return (1);
 		}
 		temp = temp->next;
@@ -128,7 +137,7 @@ int	verify_double_separators(t_token **token_lst)
 int	check_var(t_token **token_lst)
 {
 	t_token	*tmp;
-	
+
 	tmp = *token_lst;
 	if (tmp->type == PIPE) //the first node cannot be PIPE
 	{
@@ -140,7 +149,7 @@ int	check_var(t_token **token_lst)
 		set_variable(&tmp);
 		if (verify_double_separators(&tmp))
 		{
-			write(2, "syntax error\n", 13);
+			write(2, "syntax error: double separators detected\n", 42);
 			return (1);
 		}
 		tmp = tmp->next;
@@ -159,7 +168,7 @@ int	char_isspace(int c)
 bool	input_is_space(char *input) //for checking if the input is only space
 {
 	int	i;
-	
+
 	i = 0;
 	while (input[i])
 	{


### PR DESCRIPTION
When running our `minishell` and trying to open a `heredoc` two syntax errors are thrown, I debugged a bit to help.
In order to replicate the problem:
- `make` or `make debug`
- `./minishell`
- command for our minishell: `cat << EOF`

Feel free to take over this branch.