### PR TITLE
feat: PWD built-in

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,11 +25,7 @@
         },
         {
           "description": "Follow forked processes",
-          "text": "set follow-fork-mode parent"
-        },
-        {
-          "description": "Do not detach from parent after fork",
-          "text": "set detach-on-fork off"
+          "text": "set follow-fork-mode child"
         }
       ]
     },

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ SRC = main.c \
 	builtins/echo.c \
 	builtins/exit.c \
 	builtins/cd.c \
+	builtins/pwd.c \
 	debug.c
 
 SRC_TEST = create_commands.c \
@@ -67,6 +68,7 @@ SRC_TEST = create_commands.c \
 	builtins/exit.c \
 	builtins/echo.c \
 	builtins/cd.c \
+	builtins/pwd.c \
 	debug.c \
 	tests.c
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ That would leave in the main folder only crucial files:
 - [ ] enrich `ft_handle_redirections` to work with heredoc
 - [ ] test & debug redirections in longer pipe with heredoc
 
+- [ ] Check signal handling in both modes - interactive and non-interactive
+- [ ] test for handling single and double quotes as per subject requirements
 
 ## TODO for minishell (aka. our Backlog)
 - [x] (Z) create mocs of the `t_data` and `s_command` in order to be able to work on execution part

--- a/builtins/pwd.c
+++ b/builtins/pwd.c
@@ -12,6 +12,7 @@ void	ft_pwd(void)
 	{
 		free(buff);
 		buff_size *= 2;
+		buff = ft_calloc(sizeof(char), buff_size);
 	}
 	ft_printf("%s\n", buff);
 	free(buff);

--- a/builtins/pwd.c
+++ b/builtins/pwd.c
@@ -1,0 +1,18 @@
+
+# include "minishell.h"
+
+void	ft_pwd(void)
+{
+	char	*buff;
+	int		buff_size;
+
+	buff_size = 42;
+	buff = ft_calloc(sizeof(char), buff_size);
+	while (getcwd(buff, buff_size) == NULL)
+	{
+		free(buff);
+		buff_size *= 2;
+	}
+	ft_printf("%s\n", buff);
+	free(buff);
+}

--- a/execution/ft_process.c
+++ b/execution/ft_process.c
@@ -65,6 +65,11 @@ void	ft_process(t_global *global)
 			cmd_i->path = resolve_command_path(extract_env_var(ENV_PATH, global->env), cmd_i->command);
 		if (ft_strncmp(cmd_i->command, EXIT, 5) == 0)
 			ft_exit(global);
+		if (ft_strncmp(cmd_i->command, CD, 3) == 0)
+		{
+			ft_cd(cmd_i);
+			break ;
+		}
 		cmd_i->cmd_pid = fork();
 		if (cmd_i->cmd_pid == -1)
 		{

--- a/execution/ft_run_builtin.c
+++ b/execution/ft_run_builtin.c
@@ -16,8 +16,6 @@ void	ft_run_builtin(t_command *cmd, t_global *data)
 {
 	if (ft_strncmp(cmd->command, ECHO, 5) == 0)
 		ft_echo(cmd->args);
-	if (ft_strncmp(cmd->command, CD, 3) == 0)
-		ft_cd(cmd);
-	if (ft_strncmp(cmd->command, "pwd", 4) == 0)
+	if (ft_strncmp(cmd->command, PWD, 4) == 0)
 		ft_pwd();
 }

--- a/execution/ft_run_builtin.c
+++ b/execution/ft_run_builtin.c
@@ -18,4 +18,6 @@ void	ft_run_builtin(t_command *cmd, t_global *data)
 		ft_echo(cmd->args);
 	if (ft_strncmp(cmd->command, CD, 3) == 0)
 		ft_cd(cmd);
+	if (ft_strncmp(cmd->command, "pwd", 4) == 0)
+		ft_pwd();
 }

--- a/execution/resolve_command_path.c
+++ b/execution/resolve_command_path.c
@@ -22,7 +22,7 @@ bool	ft_is_our_builtin(char *cmd)
 		return (true);
 	if (ft_strncmp(EXIT, cmd, 5) == 0)
 		return (true);
-	if (ft_strncmp("pwd", cmd, 4) == 0)
+	if (ft_strncmp(PWD, cmd, 4) == 0)
 		return (true);
 	return (false);
 }

--- a/execution/resolve_command_path.c
+++ b/execution/resolve_command_path.c
@@ -22,6 +22,8 @@ bool	ft_is_our_builtin(char *cmd)
 		return (true);
 	if (ft_strncmp(EXIT, cmd, 5) == 0)
 		return (true);
+	if (ft_strncmp("pwd", cmd, 4) == 0)
+		return (true);
 	return (false);
 }
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -35,6 +35,7 @@
 # define EXIT "exit"
 # define CD "cd"
 # define ECHO "echo"
+# define PWD "pwd"
 
 # define PROMPT "\e[0;35mminishell$ \e[0m"
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -214,6 +214,7 @@ void	ft_run_builtin(t_command *cmd, t_global *data);
 void	ft_echo(char **args);
 void	ft_cd(t_command *cmd);
 void	ft_exit(t_global *data);
+void	ft_pwd(void);
 
 // Test functions
 void	run_tests(char **env);


### PR DESCRIPTION
This PR adds a built-in PWD command to the shell and updates builtin handling for improved clarity.
- Added a PWD macro and ft_pwd declaration in minishell.h
- Updated resolve_command_path.c and ft_run_builtin.c to support the PWD builtin
- Added a new builtins/pwd.c implementation and adjusted cd builtin handling in ft_process.c