### PR TITLE
Fix export

### DIFF
--- a/initialization.c
+++ b/initialization.c
@@ -39,6 +39,7 @@ bool	init_env(t_global *global, char **env)
 			return (false);
 		}
 		content->name_value = ft_split(env[i], '=');
+		content->name_value[0] = ft_strjoin(content->name_value[0], "=");
 		if (!content->name_value)
 		{
 			free(content);

--- a/main.c
+++ b/main.c
@@ -59,8 +59,8 @@ void	minishell_interactive(t_global *global)
 		set_signals_noninteractive();
 		if (parse_user_input(global))
 		{
-			//print_token_list(&global->token);
-			//print_cmd_list(global);
+			print_token_list(&global->token);
+			print_cmd_list(global);
 			ft_process(global);
 		}
 		//g_last_exit_code = execute(global);

--- a/var_expander.c
+++ b/var_expander.c
@@ -187,8 +187,9 @@ static int	var_exists(t_global *global, char *var)
 	while (env && env->content)
 	{
 		content = (t_minishell_env*) env->content;
-		if (ft_strncmp(content->name_value[0], var, len) == 0)
+		if (ft_strncmp(content->name_value[0], var, len) == 0) {
 			return (0);
+		}
 		env = env->next;
 	}
 	return (1);
@@ -212,7 +213,7 @@ static char	*search_env_var(t_global *global, char *var)
 			break ;
 		env = env->next;
 	}
-	str = ft_strdup(content->name_value[0] + len);
+	str = ft_strdup(content->name_value[1]);
 	return (str);
 }
 


### PR DESCRIPTION
`echo $USER` works now

the issue was with variable name. 
Previously `env` was defined like this:
```
USER=marlena
PATH=/bin/...
...
```
so variable name contained `=` at the end whereas `t_minishell_env` under `name_value[0]` did not.
 
See this line:
```
content->name_value[0] = ft_strjoin(content->name_value[0], "=");
```

After the fix variables are searchable.