### PR TITLE
debugging issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 minishell
 tester
+minishell_tester

--- a/builtins/exit.c
+++ b/builtins/exit.c
@@ -75,6 +75,7 @@ static void	handle_exit_err(t_command *cmd, t_global *g, int code)
 {
 	ft_printf("exit\n");
 	g->last_exit_code = code;
+	// printf("[debug] handle_exit_err, last_exit_code: %d\n", code);
 	if (code == 1)
 		ft_printf("%s %s: too many arguments\n", MINISHELL, cmd->command);
 	else if (code == 2)

--- a/execution/ft_create_pipe.c
+++ b/execution/ft_create_pipe.c
@@ -19,6 +19,7 @@ static void	ft_chandle_parent_io(t_command *cmd);
 
 void	ft_handle_redirections(t_command *cmd)
 {
+	// printf("[debug] inside ft_handle_redirections\n");
 	if (cmd->cmd_pid == 0)
 	{
 		ft_chandle_child_pipe(cmd);

--- a/execution/ft_exec_utils.c
+++ b/execution/ft_exec_utils.c
@@ -110,11 +110,14 @@ void	ft_execute_child_proc(t_command *cmd, t_global *global)
 	if (cmd->is_builtin && !cmd->status_request)
 	{
 		global->last_exit_code = ft_run_builtin(cmd, global);
+		// printf("[debug] ft_execute_child_proc, last_exit_code: %d\n", global->last_exit_code);
 		ft_exit(global, cmd->command, global->last_exit_code);
 	}
 	else
 	{
-		execve(cmd->path, cmd->args, ft_execve_env(global->env));
+		int ret = execve(cmd->path, cmd->args, ft_execve_env(global->env));
+
+		// printf("[debug] ft_execute_child_proc, execve: %d\n", ret);
 		ft_exit(global, cmd->command, EXIT_FAILURE);
 	}
 }

--- a/execution/ft_process.c
+++ b/execution/ft_process.c
@@ -33,8 +33,10 @@ void	ft_process(t_global *global)
 		if (cmd->cmd_pid > 0 && cmd->cmd_pid != last_waited_pid)
 		{
 			waitpid(cmd->cmd_pid, &wstatus, 0);
-			if (WIFEXITED(wstatus))
+			if (WIFEXITED(wstatus)) {
 				global->last_exit_code = WEXITSTATUS(wstatus);
+				// printf("[debug] ft_process, last_exit_code: %d\n", global->last_exit_code);
+			}
 		}
 	}
 }
@@ -99,21 +101,35 @@ static void	ft_execute(t_global *global, pid_t *last_waited_pid)
 	int			wstatus;
 
 	cmd = global->cmd;
+	// printf("[debug] ft_execute\n");
 	while (cmd)
 	{
-		if (cmd->cmd_pid == 0)
+		if (cmd->cmd_pid == 0) {
 			ft_execute_child_proc(cmd, global);
+			// printf("[debug]\tft_execute_child_proc\n");
+		}
 		else if (cmd->cmd_pid > 0 && global->is_global)
 		{
 			if (!cmd->pipe_output && cmd->cmd_pid > 0)
 			{
+				// printf("[debug]\t!pipe_output, pid not 0\n");
 				waitpid(cmd->cmd_pid, &wstatus, 0);
 				*last_waited_pid = cmd->cmd_pid;
 			}
-			else if (cmd == global->cmd && cmd->cmd_pid > 0)
+			else if (cmd == global->cmd && cmd->cmd_pid > 0) {
+				// printf("[debug]\there 3\n");
 				waitpid(cmd->cmd_pid, &wstatus, WNOHANG);
-			if (WIFEXITED(wstatus))
+			}
+			if (WIFEXITED(wstatus)) {
 				global->last_exit_code = WEXITSTATUS(wstatus);
+				// printf("[debug]\tlast exit code %d\n", global->last_exit_code);
+				if (global->last_exit_code != 0) {
+					printf("here early break\n");
+					break;
+				}
+			} else {
+				// printf("[debug]\tnot exited\n");
+			}
 		}
 		cmd = cmd->next;
 	}

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -193,11 +193,11 @@ char		*var_expander_heredoc(t_global *global, char *str);
 int			handle_quotes(t_global *global);
 
 // parse commands
-void		create_commands(t_global *global, t_token *token);
+bool		create_commands(t_global *global, t_token *token);
 void		parse_word(t_command **cmd, t_token **token_lst, t_global *g);
 void		parse_input(t_global *global, t_command **last_cmd,
 				t_token **token_lst);
-void		parse_trunc(t_command **last_cmd, t_token **token_lst);
+int		parse_trunc(t_command **last_cmd, t_token **token_lst);
 void		parse_append(t_command **last_cmd, t_token **token_lst);
 void		parse_pipe(t_command **last_cmd, t_token **token_lst);
 void		parse_heredoc(t_global *global, t_command **last_cmd,

--- a/main.c
+++ b/main.c
@@ -31,8 +31,11 @@ void	minishell_interactive(t_global *global)
 		set_signals_interactive();
 		global->user_input = readline(PROMPT);
 		set_signals_noninteractive();
-		if (parse_user_input(global))
+		if (parse_user_input(global)) {
+			// print_cmd_list(global);
 			ft_process(global);
+		} else
+			global->last_exit_code = 1;
 		free_global(global, false);
 	}
 }

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -114,6 +114,5 @@ bool	parse_user_input(t_global *global)
 		return (false);
 	var_expander(global, &global->token);
 	handle_quotes(global);
-	create_commands(global, global->token);
-	return (true);
+	return (create_commands(global, global->token));
 }


### PR DESCRIPTION
Debugging issue with TRUNC when file does not exist or is inaccessible.

While exiting early during parsing helps with these tests:
```
Test  85: ✅ ls >./outfiles/outfile01 >./test_files/invalid_permission 
Test  86: ✅ ls >"./outfiles/outfile with spaces" 
Test  87: ✅ ls >"./outfiles/outfile""1""2""3""4""5" 
Test  88: ✅ ls >"./outfiles/outfile01" >./test_files/invalid_permission >"./outfiles/outfile02" 
Test  89: ✅ ls >./test_files/invalid_permission >"./outfiles/outfile01" >./test_files/invalid_permission 
```

it's causing issues here, where pipe is used `|` at the end of command.
This suggests exit code needs to be managed during execution stage.

```
Test  97: ❌ echo hi >./test_files/invalid_permission | echo bye 
mini output = ()
bash output = (bye)
mini exit code = 1
bash exit code = 0
Test  98: ❌ echo hi >./test_files/invalid_permission >./outfiles/outfile01 | echo bye 
mini output = ()
bash output = (bye)
mini exit code = 1
bash exit code = 0
```
