### PR TITLE
fix: Parent built-ins working fine with redirections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/12/04 15:20:00 by zslowian          #+#    #+#              #
-#    Updated: 2025/05/04 20:40:31 by zslowian         ###   ########.fr        #
+#    Updated: 2025/05/05 10:11:41 by zslowian         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -50,6 +50,7 @@ SRC = main.c \
 	execution/ft_redirections.c \
 	execution/ft_redirects_utils.c \
 	execution/ft_run_builtin.c \
+	execution/ft_std_backup.c \
 	parser/characters.c \
 	parser/clean_unnecessary_fds.c \
 	parser/create_commands.c \

--- a/execution/ft_create_pipe.c
+++ b/execution/ft_create_pipe.c
@@ -6,7 +6,7 @@
 /*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/11 09:56:26 by zslowian          #+#    #+#             */
-/*   Updated: 2025/05/05 12:26:51 by zslowian         ###   ########.fr       */
+/*   Updated: 2025/05/05 12:47:21 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -110,6 +110,8 @@ void	ft_chandle_parent_io(t_command *cmd, t_global *g,
 	if (prev_cmd && prev_cmd->cmd_pid == -1 && prev_cmd->pipe_output) // executing parent built-in writing to pipe ()
 	{
 		prev_cmd->stdout_backup = create_stdout_backup();
+		if (prev_cmd->stdout_backup)
+			ft_exit(g, "ft_chandle_parent_io failed to create stdout backup", 1);
 		close(prev_cmd->pipe_fd[0]);
 		dup2(prev_cmd->pipe_fd[1], STDOUT_FILENO);
 		close(prev_cmd->pipe_fd[1]);

--- a/execution/ft_create_pipe.c
+++ b/execution/ft_create_pipe.c
@@ -6,7 +6,7 @@
 /*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/11 09:56:26 by zslowian          #+#    #+#             */
-/*   Updated: 2025/05/04 08:56:23 by zslowian         ###   ########.fr       */
+/*   Updated: 2025/05/05 10:26:25 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -107,7 +107,14 @@ void	ft_chandle_parent_io(t_command *cmd, t_global *g,
 			lst = lst->next;
 		}
 	}
-	if (prev_cmd && prev_cmd->pipe_output)
+	if (prev_cmd && prev_cmd->cmd_pid == -1 && prev_cmd->pipe_output) // executing parent built-in writing to pipe ()
+	{
+		prev_cmd->stdout_backup = create_stdout_backup();
+		close(prev_cmd->pipe_fd[0]);
+		dup2(prev_cmd->pipe_fd[1], STDOUT_FILENO);
+		close(prev_cmd->pipe_fd[1]);
+	}
+	else if (prev_cmd && prev_cmd->pipe_output)
 	{
 		close(prev_cmd->pipe_fd[0]);
 		close(prev_cmd->pipe_fd[1]);

--- a/execution/ft_create_pipe.c
+++ b/execution/ft_create_pipe.c
@@ -6,7 +6,7 @@
 /*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/11 09:56:26 by zslowian          #+#    #+#             */
-/*   Updated: 2025/05/05 10:26:25 by zslowian         ###   ########.fr       */
+/*   Updated: 2025/05/05 12:26:51 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -118,6 +118,11 @@ void	ft_chandle_parent_io(t_command *cmd, t_global *g,
 	{
 		close(prev_cmd->pipe_fd[0]);
 		close(prev_cmd->pipe_fd[1]);
+	}
+	if (cmd->final_io && cmd->final_io->outfile)
+	{
+		cmd->stdout_backup = create_stdout_backup();
+		ft_open_final_outfile(g, &cmd->final_io);
 	}
 }
 

--- a/execution/ft_exec_utils.c
+++ b/execution/ft_exec_utils.c
@@ -6,7 +6,7 @@
 /*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 19:08:40 by zslowian          #+#    #+#             */
-/*   Updated: 2025/05/04 18:25:57 by zslowian         ###   ########.fr       */
+/*   Updated: 2025/05/05 10:40:37 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,7 +51,7 @@ char	*resolve_command_path(t_global *g, char *path, char *cmd)
 	ex = NULL;
 	(void)g;
 	if (!path)
-		return (NULL);
+		return (ft_strdup(cmd));
 	candidates = ft_split(path, ':');
 	if (candidates)
 	{

--- a/execution/ft_input.c
+++ b/execution/ft_input.c
@@ -6,7 +6,7 @@
 /*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 18:48:04 by zslowian          #+#    #+#             */
-/*   Updated: 2025/05/04 09:04:03 by zslowian         ###   ########.fr       */
+/*   Updated: 2025/05/05 10:01:49 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,7 +56,7 @@ void	ft_execute_cmd(t_global *g, t_command *cmd, pid_t prev_pid)
 	wstatus = 0;
 	if (cmd->cmd_pid == 0)
 		ft_execute_child_proc(cmd, g, prev_pid);
-	else
+	else if (g->is_global)
 	{
 		if (cmd->cmd_pid == -1)
 			ft_run_parent_builtins(cmd, g);
@@ -100,17 +100,17 @@ void	ft_check_path(char *path, int *error)
 	else if (access(path, X_OK))
 	{
 		*error = 126;
-		if (dir_or_cmd) 
+		if (dir_or_cmd)
 			ft_minishell_perror(path, EACCES);
 		else {
 			*error = 127;
 			return ft_handle_minishell_err(path, ": command not found\n");
 		}
-			
+
 	}
 	if (S_ISDIR(info.st_mode)) {
 		*error = 126;
-		if (dir_or_cmd) 
+		if (dir_or_cmd)
 			return ft_handle_minishell_err(path, ": Is a directory\n");
 		*error = 127;
 		return ft_handle_minishell_err(path, ": command not found\n");

--- a/execution/ft_process.c
+++ b/execution/ft_process.c
@@ -6,7 +6,7 @@
 /*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/05 15:11:29 by zslowian          #+#    #+#             */
-/*   Updated: 2025/05/04 17:57:49 by zslowian         ###   ########.fr       */
+/*   Updated: 2025/05/05 10:19:15 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,6 +43,8 @@ void	ft_run_parent_builtins(t_command *cmd, t_global *global)
 		ft_printf("%s %s: command not found\n", MINISHELL, cmd->command);
 		global->last_exit_code = 127;
 	}
+	if (cmd->pipe_output || (cmd->final_io && cmd->final_io->outfile))
+		restore_stdout_from_backup(cmd->stdout_backup);
 }
 
 static void	ft_pipex(t_global *g)

--- a/execution/ft_process.c
+++ b/execution/ft_process.c
@@ -6,7 +6,7 @@
 /*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/05 15:11:29 by zslowian          #+#    #+#             */
-/*   Updated: 2025/05/05 10:19:15 by zslowian         ###   ########.fr       */
+/*   Updated: 2025/05/05 12:42:02 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,25 +26,35 @@ void	ft_process(t_global *global)
 	}
 }
 
-void	ft_run_parent_builtins(t_command *cmd, t_global *global)
+void	ft_run_parent_builtins(t_command *cmd, t_global *g)
 {
+	int	check;
+
+	check = 0;
 	if (cmd->command && ft_strncmp(cmd->command, EXIT, ft_strlen(EXIT)) == 0)
-		ft_mini_exit_wrapper(cmd, global);
+		ft_mini_exit_wrapper(cmd, g);
 	else if (cmd->command && ft_strncmp(cmd->command, CD, ft_strlen(CD)) == 0)
-		global->last_exit_code = ft_cd(cmd, global);
+		g->last_exit_code = ft_cd(cmd, g);
 	else if (cmd->command && ft_strncmp(cmd->command,
 			EXPORT, ft_strlen(EXPORT)) == 0)
-		ft_mini_export_wrapper(cmd, global);
+		ft_mini_export_wrapper(cmd, g);
 	else if (cmd->command && ft_strncmp(cmd->command,
 			UNSET, ft_strlen(UNSET)) == 0)
-		ft_unset(cmd, global);
+		ft_unset(cmd, g);
 	else if (cmd->status_request)
 	{
 		ft_printf("%s %s: command not found\n", MINISHELL, cmd->command);
-		global->last_exit_code = 127;
+		g->last_exit_code = 127;
 	}
 	if (cmd->pipe_output || (cmd->final_io && cmd->final_io->outfile))
-		restore_stdout_from_backup(cmd->stdout_backup);
+	{
+		check = restore_stdout_from_backup(cmd->stdout_backup);
+		if (check)
+		{
+			ft_minishell_perror("ft_run_parent_builtins failed to restore stdout backup", 1);
+			ft_exit(g, "ft_run_parent_builtins failed to restore stdout backup", 1);
+		}
+	}
 }
 
 static void	ft_pipex(t_global *g)

--- a/execution/ft_redirects_utils.c
+++ b/execution/ft_redirects_utils.c
@@ -6,7 +6,7 @@
 /*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/02 15:19:15 by zslowian          #+#    #+#             */
-/*   Updated: 2025/05/03 16:29:37 by zslowian         ###   ########.fr       */
+/*   Updated: 2025/05/05 10:18:42 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -81,13 +81,13 @@ void	ft_handle_child_io_lst_node(t_global *g, t_command *cmd, t_io_fds *node)
 void	ft_handle_parent_io_lst_node(t_global *g, t_command *cmd,
 			t_io_fds *node)
 {
-	if (node->infile)
+	if (node->infile) // delete - parent builtins should not have any inputs
 	{
 		if (node->heredoc_delimiter != NULL && node->use_heredoc)
 			ft_copy_input_to_final_io(node, cmd, g, true);
 		else if (node->heredoc_delimiter == NULL)
 			ft_copy_input_to_final_io(node, cmd, g, false);
 	}
-	if (node->outfile)
+	if (node->outfile) // make sure we are restoring stdout
 		ft_copy_output_to_final_io(node, cmd, g);
 }

--- a/execution/ft_run_builtin.c
+++ b/execution/ft_run_builtin.c
@@ -6,7 +6,7 @@
 /*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/09 17:54:00 by zslowian          #+#    #+#             */
-/*   Updated: 2025/05/04 22:33:14 by zslowian         ###   ########.fr       */
+/*   Updated: 2025/05/05 09:45:41 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,5 +69,6 @@ void	ft_split_child_parent_run(t_global *g, t_command *cmd,
 		cmd->path = resolve_command_path(g, path_values, cmd->command);
 		free_ptr((void **) &path_values);
 	}
+	free_ptr((void **) &path_values);
 	ft_handle_redirections(cmd, g, prev_cmd);
 }

--- a/execution/ft_run_builtin.c
+++ b/execution/ft_run_builtin.c
@@ -6,7 +6,7 @@
 /*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/09 17:54:00 by zslowian          #+#    #+#             */
-/*   Updated: 2025/05/05 09:45:41 by zslowian         ###   ########.fr       */
+/*   Updated: 2025/05/05 10:45:42 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,16 +59,15 @@ void	ft_split_child_parent_run(t_global *g, t_command *cmd,
 {
 	char	*path_values;
 
-	path_values = ft_get_env_var_value(g->env, "PATH");
 	if (!is_parent_builtin(cmd))
 		ft_safe_fork(g, cmd);
 	if (cmd->cmd_pid == 0 && ft_strcmp(cmd->command, "\0") == 0)
 		ft_exit(g, cmd->command, EXIT_SUCCESS);
-	if (!cmd->is_builtin && path_values)
+	if (cmd->cmd_pid == 0)
 	{
+		path_values = ft_get_env_var_value(g->env, "PATH");
 		cmd->path = resolve_command_path(g, path_values, cmd->command);
 		free_ptr((void **) &path_values);
 	}
-	free_ptr((void **) &path_values);
 	ft_handle_redirections(cmd, g, prev_cmd);
 }

--- a/execution/ft_std_backup.c
+++ b/execution/ft_std_backup.c
@@ -6,7 +6,7 @@
 /*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 10:11:06 by zslowian          #+#    #+#             */
-/*   Updated: 2025/05/05 10:26:40 by zslowian         ###   ########.fr       */
+/*   Updated: 2025/05/05 12:42:05 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,13 +19,14 @@ int	create_stdout_backup(void)
 {
 	int	backup_fd;
 
+	backup_fd = 0;
 	backup_fd = dup(STDOUT_FILENO);
 	if (backup_fd == -1)
 	{
 		perror("dup failed");
-		return -1;
+		return (-1);
 	}
-	return backup_fd;
+	return (backup_fd);
 }
 
 int	restore_stdout_from_backup(int backup_fd)
@@ -33,8 +34,8 @@ int	restore_stdout_from_backup(int backup_fd)
 	if	(dup2(backup_fd, STDOUT_FILENO) == -1)
 	{
 		perror("dup2 failed");
-		return -1;
+		return (-1);
 	}
 	close(backup_fd);
-	return 0;
+	return (0);
 }

--- a/execution/ft_std_backup.c
+++ b/execution/ft_std_backup.c
@@ -1,34 +1,40 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   commands_list.c                                    :+:      :+:    :+:   */
+/*   ft_std_backup.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/04/23 17:58:27 by zslowian          #+#    #+#             */
-/*   Updated: 2025/05/05 10:06:19 by zslowian         ###   ########.fr       */
+/*   Created: 2025/05/05 10:11:06 by zslowian          #+#    #+#             */
+/*   Updated: 2025/05/05 10:26:40 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-t_command	*lst_new_cmd(void)
-{
-	t_command	*new_cmd;
+int	create_stdout_backup(void);
+int	restore_stdout_from_backup(int backup_fd);
 
-	new_cmd = ft_calloc(sizeof(t_command), 1);
-	if (new_cmd == NULL)
-		ft_exit(NULL, "lst_new_cmd", 1);
-	new_cmd->pipe_fd[0] = -1;
-	new_cmd->pipe_fd[1] = -1;
-	new_cmd->cmd_pid = -1;
-	new_cmd->stdout_backup = -1;
-	return (new_cmd);
+int	create_stdout_backup(void)
+{
+	int	backup_fd;
+
+	backup_fd = dup(STDOUT_FILENO);
+	if (backup_fd == -1)
+	{
+		perror("dup failed");
+		return -1;
+	}
+	return backup_fd;
 }
 
-t_command	*lst_last_cmd(t_list *lst)
+int	restore_stdout_from_backup(int backup_fd)
 {
-	while (lst->next != NULL)
-		lst = lst->next;
-	return ((t_command *) lst->content);
+	if	(dup2(backup_fd, STDOUT_FILENO) == -1)
+	{
+		perror("dup2 failed");
+		return -1;
+	}
+	close(backup_fd);
+	return 0;
 }

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/04 15:15:23 by zslowian          #+#    #+#             */
-/*   Updated: 2025/05/04 23:35:35 by zslowian         ###   ########.fr       */
+/*   Updated: 2025/05/05 10:12:38 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -77,6 +77,7 @@ typedef struct s_command
 	int					pipe_fd[2];
 	bool				is_builtin;
 	bool				status_request;
+	int					stdout_backup;
 	pid_t				cmd_pid;
 	t_list				*io_fds;
 	t_io_fds			*final_io;
@@ -167,6 +168,8 @@ void			ft_check_path(char *path, int *error);
 void			ft_command_not_found(char *path, int *error);
 void			ft_handle_minishell_err(char *cmd, char *error);
 t_minishell_env	*init_env_content(char *name, char *value);
+int				create_stdout_backup(void);
+int				restore_stdout_from_backup(int backup_fd);
 
 //initialization
 bool		init_global(t_global *global, char **env);


### PR DESCRIPTION
This PR ensures that parent built-ins correctly handle pipe outputs by backing up and restoring stdout when necessary. Key changes include:
- Adding a stdout_backup field and corresponding helper functions to create and restore stdout in the command structure.
- Refining the logic in the pipe creation and redirection code to better support parent built-ins.
- Updating header comments and minor control flow adjustments for clarity.
