### PR TITLE
fix: exit with error & CFLAGS on Linux

### DIFF
--- a/builtins/exit.c
+++ b/builtins/exit.c
@@ -6,7 +6,7 @@
 /*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/01 18:53:18 by zslowian          #+#    #+#             */
-/*   Updated: 2025/05/04 08:26:43 by zslowian         ###   ########.fr       */
+/*   Updated: 2025/05/05 14:58:09 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,13 +20,12 @@ static void	handle_exit_err(t_command *cmd, t_global *g, int code);
 
 void	ft_exit(t_global *global, char *cmd, int status)
 {
-	(void)cmd;
+	if (global->is_global == true && !(ft_strcmp(cmd, EXIT) == 0 && status))
+		ft_printf("exit\n");
 	if (global)
 		free_global(global, true);
 	if (global->env)
 		ft_lstclear(&global->env, ft_clear_minishell_env);
-	if (global->is_global == true)
-		ft_printf("exit\n");
 	exit(status);
 }
 

--- a/command_vars.c
+++ b/command_vars.c
@@ -6,7 +6,7 @@
 /*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/23 17:58:27 by zslowian          #+#    #+#             */
-/*   Updated: 2025/05/04 07:39:01 by zslowian         ###   ########.fr       */
+/*   Updated: 2025/05/05 14:47:31 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -124,7 +124,7 @@ void	parse_word(t_command **curr_cmd, t_token **curr_token)
 		{
 			if (token->type == VAR && contains_space(token->str))
 				split_var_cmd_token(*curr_cmd, token->str);
-			else if (!ft_strcmp(token->str, "") == 0)
+			else if (!(ft_strcmp(token->str, "") == 0))
 			{
 				(*curr_cmd)->command = ft_strdup(token->str);
 				(*curr_cmd)->is_builtin = ft_is_our_builtin(*curr_cmd);

--- a/debug/debug.c
+++ b/debug/debug.c
@@ -6,7 +6,7 @@
 /*   By: zslowian <zslowian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/23 18:03:42 by zslowian          #+#    #+#             */
-/*   Updated: 2025/05/02 19:10:35 by zslowian         ###   ########.fr       */
+/*   Updated: 2025/05/05 14:49:07 by zslowian         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,6 +59,7 @@ void	print_cmd_list(t_global *global)
 	t_command	*cmd;
 	t_list		*lst;
 
+	lst = NULL;
 	if (global && global->cmd)
 		lst = global->cmd;
 	printf("\n---- COMMAND LIST\n");


### PR DESCRIPTION
This PR fixes two logic issues: one with token parsing in command_vars.c and another by reducing duplicate output in builtins/exit.c.